### PR TITLE
Refactor internal structures for the compared JSON

### DIFF
--- a/src/components/DisplayDifference.scss
+++ b/src/components/DisplayDifference.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.DisplayValue {
+.ComparedValue {
   &.left {
     background-color: $bg-red-color;
   }
@@ -16,29 +16,27 @@
   &.right {
     background-color: $bg-green-color;
   }
+
+  .mixed {
+    background-color: $orange-color;
+  }
+
+  .collapsable {
+    cursor: pointer;
+
+    &:hover {
+      background-color: $bg-highlight-color;
+    }
+
+    &.mixed:hover {
+      background-color: $orange-highlight-color;
+    }
+  }
 }
 
-.DisplayResult {
+.ComparedValues {
   pre {
     margin: 0;
     padding: $gap-2x-small;
-  }
-  
-  &.collapsed {
-    pre {
-      cursor: pointer;
-    
-      &:hover {
-        background-color: $bg-highlight-color;
-      }
-    }
-
-    &.differ > pre {
-      background-color: $orange-color;
-      
-      &:hover {
-        background-color: $orange-highlight-color;
-      }
-    }
   }
 }

--- a/src/components/ManualInput.scss
+++ b/src/components/ManualInput.scss
@@ -9,6 +9,7 @@
   }
 
   .action {
+    margin-bottom: $gap-large;
     text-align: center;
 
     .compare {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,13 @@
-import {Compare, JsonCompared, compareJsons} from './utils'
+import {
+  compareJsons,
+  CompareResult,
+  ComparedJson,
+  JsonTypedValue,
+  createBothValue,
+  createLeftValue,
+  createRightValue,
+  addKey,
+} from './utils'
 
 test('returns error when left is invalid json', () => {
   const errorResult = compareJsons('foo', '{}')
@@ -11,118 +20,292 @@ test('returns error when right is invalid json', () => {
 })
 
 test('evaluates two null values as same', () => {
-  const errorResult = compareJsons('null', 'null')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(true)
+  const expectedComparedJson = createBothSame({
+    type: 'null',
+    value: null,
   })
+  const actualResult = compareJsons('null', 'null')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two number values as same', () => {
-  const errorResult = compareJsons('1', '1')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(true)
+  const expectedComparedJson = createBothSame({
+    type: 'number',
+    value: 1,
   })
-})
-
-test('evaluates two boolean values as same', () => {
-  const errorResult = compareJsons('  "foo"', '"foo"')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(true)
-  })
+  const actualResult = compareJsons('1', '1')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two string values as same', () => {
-  const errorResult = compareJsons('true', 'true')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(true)
+  const expectedComparedJson = createBothSame({
+    type: 'string',
+    value: 'foo',
   })
+  const actualResult = compareJsons('  "foo"', '"foo"')
+  verifyResult(expectedComparedJson, actualResult)
+})
+
+test('evaluates two boolean values as same', () => {
+  const expectedComparedJson = createBothSame({
+    type: 'boolean',
+    value: true,
+  })
+  const actualResult = compareJsons('true', 'true')
+  verifyResult(expectedComparedJson, actualResult)
+})
+
+test('evaluates two empty arrays as same', () => {
+  const expectedComparedJson = createBothSame({
+    type: 'array',
+    value: {
+      isSame: true,
+      comparedValues: [],
+    },
+  })
+  const actualResult = compareJsons('[]', '[]')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two arrays as same', () => {
-  const errorResult = compareJsons('[1,2,3]', '[1, 2, 3]')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('array')
-    if (r.comparedType === 'array') {
-      expect(r.isSame).toEqual(true)
-    }
+  const expectedComparedJson = createBothSame({
+    type: 'array',
+    value: {
+      isSame: true,
+      comparedValues: [
+        createBothValue({type: 'null', value: null}),
+        createBothValue({type: 'boolean', value: true}),
+        createBothValue({type: 'number', value: 3}),
+        createBothValue({type: 'string', value: 'foo'}),
+        createBothValue({type: 'array', value: {isSame: true, comparedValues: []}}),
+        createBothValue({type: 'object', value: {isSame: true, comparedValues: []}}),
+      ],
+    },
   })
+  const actualResult = compareJsons(
+    '[null, true, 3, "foo", [], {}]',
+    '[null, true, 3, "foo", [], {}]',
+  )
+  verifyResult(expectedComparedJson, actualResult)
+})
+
+test('evaluates two empty objects as same', () => {
+  const expectedComparedJson = createBothSame({
+    type: 'object',
+    value: {
+      isSame: true,
+      comparedValues: [],
+    },
+  })
+  const actualResult = compareJsons('{}', ' {} ')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two objects as same when keys are not soted', () => {
-  const errorResult = compareJsons('{"foo":"1","bar": "1"}', ' {"bar": "1","foo":"1"} ')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('object')
-    if (r.comparedType === 'object') {
-      expect(r.isSame).toEqual(true)
-    }
+  const expectedComparedJson = createBothSame({
+    type: 'object',
+    value: {
+      isSame: true,
+      comparedValues: [
+        addKey(createBothValue)(['bar', {type: 'number', value: 1}]),
+        addKey(createBothValue)([
+          'foo',
+          {type: 'array', value: {isSame: true, comparedValues: []}},
+        ]),
+      ],
+    },
   })
+  const actualResult = compareJsons('{"foo":[],"bar": 1}', ' {"bar": 1,"foo":[]} ')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two boolean values as different', () => {
-  const errorResult = compareJsons('true', 'false')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(false)
-  })
+  const expectedComparedJson = createDifferent(
+    {type: 'boolean', value: true},
+    {type: 'boolean', value: false},
+  )
+  const actualResult = compareJsons('true', 'false')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('evaluates two different typed values as different', () => {
-  const errorResult = compareJsons('[]', '{}')
-  failOnError(errorResult, (r) => {
-    expect(r.isSame).toEqual(false)
-  })
+  const expectedComparedJson = createDifferent(
+    {type: 'lazy', value: {type: 'raw-array', value: []}},
+    {type: 'lazy', value: {type: 'raw-object', value: {}}},
+  )
+  const actualResult = compareJsons('[]', '{}')
+  verifyResult(expectedComparedJson, actualResult)
+})
+
+test('evaluates left empty array vs right non-empty array', () => {
+  const typedArrayValue: JsonTypedValue = {
+    type: 'array',
+    value: {
+      isSame: false,
+      comparedValues: [
+        createRightValue({type: 'number', value: 1}),
+        createRightValue({type: 'number', value: 2}),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedArrayValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('[]', '[1, 2]')
+  verifyResult(expectedComparedJson, actualResult)
+})
+
+test('evaluates left non-empty array vs right empty array', () => {
+  const typedArrayValue: JsonTypedValue = {
+    type: 'array',
+    value: {
+      isSame: false,
+      comparedValues: [
+        createLeftValue({type: 'number', value: 1}),
+        createLeftValue({type: 'number', value: 2}),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedArrayValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('[1, 2]', '[]')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('finds missing value in second array', () => {
-  const errorResult = compareJsons('[1,2,3]', '[1,2]')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('array')
-    if (r.comparedType === 'array') {
-      expect(r.isSame).toEqual(false)
-      expect(r.values).toContainEqual({diffType: 'left', value: 3})
-    }
-  })
+  const typedArrayValue: JsonTypedValue = {
+    type: 'array',
+    value: {
+      isSame: false,
+      comparedValues: [
+        createBothValue({type: 'number', value: 1}),
+        createBothValue({type: 'number', value: 2}),
+        createLeftValue({type: 'number', value: 3}),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedArrayValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('[1,2,3]', '[1,2]')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('finds added value in second array', () => {
-  const errorResult = compareJsons('[1,2]', '[1,2,3]')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('array')
-    if (r.comparedType === 'array') {
-      expect(r.isSame).toEqual(false)
-      expect(r.values).toContainEqual({diffType: 'right', value: 3})
-    }
-  })
+  const typedArrayValue: JsonTypedValue = {
+    type: 'array',
+    value: {
+      isSame: false,
+      comparedValues: [
+        createBothValue({type: 'number', value: 1}),
+        createBothValue({type: 'number', value: 2}),
+        createRightValue({type: 'number', value: 3}),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedArrayValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('[1,2]', '[1,2,3]')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('finds changed key-value pair in object', () => {
-  const errorResult = compareJsons('{"a":1,"b":2,"c":3}', '{"a":1,"b":4,"c":3}')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('object')
-    if (r.comparedType === 'object') {
-      expect(r.isSame).toEqual(false)
-      expect(r.values).toContainEqual({diffType: 'both', key: 'a', value: 1})
-      expect(r.values).toContainEqual({diffType: 'left', key: 'b', value: 2})
-      expect(r.values).toContainEqual({diffType: 'right', key: 'b', value: 4})
-    }
-  })
+  const typedObjectValue: JsonTypedValue = {
+    type: 'object',
+    value: {
+      isSame: false,
+      comparedValues: [
+        addKey(createBothValue)(['a', {type: 'number', value: 1}]),
+        addKey(createLeftValue)(['b', {type: 'number', value: 2}]),
+        addKey(createRightValue)(['b', {type: 'number', value: 4}]),
+        addKey(createBothValue)(['c', {type: 'number', value: 3}]),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedObjectValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('{"a":1,"b":2,"c":3}', '{"a":1,"b":4,"c":3}')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
 test('finds added key-value pair in object', () => {
-  const errorResult = compareJsons('{"a":1,"c":3}', '{"a":1,"b":2,"c":3}')
-  failOnError(errorResult, (r) => {
-    expect(r.comparedType).toEqual('object')
-    if (r.comparedType === 'object') {
-      expect(r.isSame).toEqual(false)
-      expect(r.values).toContainEqual({diffType: 'both', key: 'a', value: 1})
-      expect(r.values).toContainEqual({diffType: 'right', key: 'b', value: 2})
-      expect(r.values).toContainEqual({diffType: 'both', key: 'c', value: 3})
-    }
-  })
+  const typedObjectValue: JsonTypedValue = {
+    type: 'object',
+    value: {
+      isSame: false,
+      comparedValues: [
+        addKey(createBothValue)(['a', {type: 'number', value: 1}]),
+        addKey(createRightValue)(['b', {type: 'number', value: 2}]),
+        addKey(createBothValue)(['c', {type: 'number', value: 3}]),
+      ],
+    },
+  }
+  const expectedComparedJson: ComparedJson = {
+    isSame: false,
+    comparedValues: [
+      {
+        comparedType: 'both',
+        typedValue: typedObjectValue,
+      },
+    ],
+  }
+  const actualResult = compareJsons('{"a":1,"c":3}', '{"a":1,"b":2,"c":3}')
+  verifyResult(expectedComparedJson, actualResult)
 })
 
-function failOnError(compare: Compare, validate: (r: JsonCompared) => void): void {
-  if (compare.status === 'ok') {
-    validate(compare.result)
+function createBothSame(typedValue: JsonTypedValue): ComparedJson {
+  return {
+    isSame: true,
+    comparedValues: [createBothValue(typedValue)],
+  }
+}
+
+function createDifferent(
+  leftTypedValue: JsonTypedValue,
+  rightTypedValue: JsonTypedValue,
+): ComparedJson {
+  return {
+    isSame: false,
+    comparedValues: [createLeftValue(leftTypedValue), createRightValue(rightTypedValue)],
+  }
+}
+
+function verifyResult(expected: ComparedJson, actual: CompareResult): void {
+  if (actual.status === 'ok') {
+    expect(actual.result).toEqual(expected)
   } else {
     fail('Expected ok result got error')
   }


### PR DESCRIPTION
The existing structures had some duplications and limitations.
In the old model, if it was not necessary an array or object was
not transformed to our internal structures, thus it was left as
a raw JSON. As consequence of this, it was hard to reuse existing
UI elements to make this raw JSON value collapsable. In the new
model, we try to reuse functionality and distinguish different
internal types making them easier to be worked with.

This commit fixes #2, i.e. making all arrays and objects collapsable
in the UI.